### PR TITLE
feat: updated libreoffice version (24.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN groupadd --gid $USER_GID $USERNAME &&\
     useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
     wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64  &&\
     chmod +x /usr/local/bin/dumb-init && \
+    echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y tesseract-ocr && \
     apt-get install -y $TESSERACT_LANGUAGES && \
@@ -26,8 +27,10 @@ RUN groupadd --gid $USER_GID $USERNAME &&\
     apt-get install -y ghostscript python3-tk && \
     apt-get install -y libgl1 && \
     apt-get install -y ocrmypdf && \
-    apt-get --no-install-recommends install -y libreoffice && \
-    apt-get install -y default-jre-headless libreoffice-java-common jodconverter
+    apt-get --no-install-recommends install -y -t bookworm-backports libreoffice && \
+    apt-get install -y default-jre-headless && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 
 COPY dist/auto-install.xml /tmp
 RUN wget -O /tmp/verapdf-installer.zip https://software.verapdf.org/releases/verapdf-installer.zip && \

--- a/teal/model.py
+++ b/teal/model.py
@@ -52,12 +52,12 @@ class OcrPdfAProfile(str, Enum):
 
 
 class LibreOfficePdfProfile(str, Enum):
-    PDFA_1a = "pdfa-1a"
+    PDFA_1B = "pdfa-1b"
     PDFA_2B = "pdfa-2b"
     PDFA_3B = "pdfa-3b"
     PDF_15 = "pdf-1.5"
     PDF_16 = "pdf-1.6"
-    # PDF17 = "pdf-1.7"
+    PDF17 = "pdf-1.7"
 
     def to_libreoffice_pdf_version(self):
         if "pdfa-" in self.value:

--- a/teal/pdf.py
+++ b/teal/pdf.py
@@ -151,7 +151,7 @@ class PdfMetaDataExtractor:
         doc_info = {}
         for key, value in pdf.docinfo.items():
             doc_info[key] = str(value)
-
+        pdf.close()
         return PdfMetaDataReport.model_validate(
             {
                 "fileName": filename,

--- a/tests/test_api_libreoffice_convert.py
+++ b/tests/test_api_libreoffice_convert.py
@@ -21,7 +21,7 @@ def test_libreoffice_convert_docx_default():
 
                 response = client.post(url="/pdf/meta", files={"file": pdf_file})
                 assert response.status_code == 200
-                assert response.json()["pdfVersion"] == "1.6"
+                assert response.json()["pdfVersion"] == "1.7"
                 assert response.json()["pdfaClaim"] is None
 
 
@@ -65,6 +65,26 @@ def test_libreoffice_convert_docx_pdf16():
                 assert response.json()["pdfaClaim"] is None
 
 
+def test_libreoffice_convert_docx_pdf17():
+    client = TestClient(api.app, raise_server_exceptions=False)
+    with open(get_path("data/doc/word_document.docx"), "rb") as f:
+        response = client.post(
+            url="/libreoffice/convert?profile=pdf-1.7", files={"file": f}
+        )
+        assert response.status_code == 200
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+            tmp.write(response.content)
+            with open(tmp.name, "rb") as pdf_file:
+                response = client.post(url="/pdf/text", files={"file": pdf_file})
+                assert response.status_code == 200
+                assert len(response.json()) == 3
+
+                response = client.post(url="/pdf/meta", files={"file": pdf_file})
+                assert response.status_code == 200
+                assert response.json()["pdfVersion"] == "1.7"
+                assert response.json()["pdfaClaim"] is None
+
+
 def test_libreoffice_convert_txt_default():
     client = TestClient(api.app, raise_server_exceptions=False)
     with open(get_path("data/doc/text_document.txt"), "rb") as f:
@@ -79,7 +99,7 @@ def test_libreoffice_convert_txt_default():
 
                 response = client.post(url="/pdf/meta", files={"file": pdf_file})
                 assert response.status_code == 200
-                assert response.json()["pdfVersion"] == "1.6"
+                assert response.json()["pdfVersion"] == "1.7"
                 assert response.json()["pdfaClaim"] is None
 
 
@@ -97,7 +117,7 @@ def test_libreoffice_convert_pdf_default():
 
                 response = client.post(url="/pdf/meta", files={"file": pdf_file})
                 assert response.status_code == 200
-                assert response.json()["pdfVersion"] == "1.6"
+                assert response.json()["pdfVersion"] == "1.7"
                 assert response.json()["pdfaClaim"] is None
 
 
@@ -131,7 +151,7 @@ def test_libreoffice_convert_pdfa1():
     client = TestClient(api.app, raise_server_exceptions=False)
     with open(get_path("data/doc/word_document.docx"), "rb") as f:
         response = client.post(
-            url="/libreoffice/convert?profile=pdfa-1a", files={"file": f}
+            url="/libreoffice/convert?profile=pdfa-1b", files={"file": f}
         )
         assert response.status_code == 200
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
@@ -140,12 +160,12 @@ def test_libreoffice_convert_pdfa1():
                 response = client.post(url="/pdfa/validate", files={"file": pdf_file})
                 assert response.status_code == 200
                 assert response.json()["compliant"] is True
-                assert response.json()["profile"] == "PDF/A-1A"
+                assert response.json()["profile"] == "PDF/A-1B"
 
                 response = client.post(url="/pdf/meta", files={"file": pdf_file})
                 assert response.status_code == 200
                 assert response.json()["pdfVersion"] == "1.4"
-                assert response.json()["pdfaClaim"] == "1A"
+                assert response.json()["pdfaClaim"] == "1B"
 
 
 def test_libreoffice_convert_pdfa2():
@@ -165,7 +185,7 @@ def test_libreoffice_convert_pdfa2():
 
                 response = client.post(url="/pdf/meta", files={"file": pdf_file})
                 assert response.status_code == 200
-                assert response.json()["pdfVersion"] == "1.6"
+                assert response.json()["pdfVersion"] == "1.7"
                 assert response.json()["pdfaClaim"] == "2B"
 
 
@@ -186,7 +206,7 @@ def test_libreoffice_convert_pdfa3():
 
                 response = client.post(url="/pdf/meta", files={"file": pdf_file})
                 assert response.status_code == 200
-                assert response.json()["pdfVersion"] == "1.6"
+                assert response.json()["pdfVersion"] == "1.7"
                 assert response.json()["pdfaClaim"] == "3B"
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,10 +2,10 @@ from teal.model import LibreOfficePdfProfile, OcrPdfAProfile
 
 
 def test_libreoffice_pdf_profile_model():
-    # assert LibreOfficePdfProfile.PDF17.to_libreoffice_pdf_version() == "17"
+    assert LibreOfficePdfProfile.PDF17.to_libreoffice_pdf_version() == "17"
     assert LibreOfficePdfProfile.PDF_16.to_libreoffice_pdf_version() == "16"
     assert LibreOfficePdfProfile.PDF_15.to_libreoffice_pdf_version() == "15"
-    assert LibreOfficePdfProfile.PDFA_1a.to_libreoffice_pdf_version() == "1"
+    assert LibreOfficePdfProfile.PDFA_1B.to_libreoffice_pdf_version() == "1"
     assert LibreOfficePdfProfile.PDFA_2B.to_libreoffice_pdf_version() == "2"
     assert LibreOfficePdfProfile.PDFA_3B.to_libreoffice_pdf_version() == "3"
 


### PR DESCRIPTION
* updated libreoffice to version to 24.2
* update pdf metadata with pikepdf when converting with libreoffice 24.x to fix pdfa/1b creation time difference between xmp and docinfo metadata